### PR TITLE
PR: T11.3.1 - 사고 조회 기본 구조 및 DTO 설계 → US11.3 머지

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,10 @@ dependencies {
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // dynamoDB
+    implementation 'software.amazon.awssdk:dynamodb:2.33.0'
+    implementation 'software.amazon.awssdk:dynamodb-enhanced:2.33.0'
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -30,11 +30,6 @@ ext {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
-
-    // Database & JPA
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    runtimeOnly 'com.mysql:mysql-connector-j'
 
     // feign
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'

--- a/src/main/java/com/smooth/accident_service/accident/dto/AccidentDetailResponseDto.java
+++ b/src/main/java/com/smooth/accident_service/accident/dto/AccidentDetailResponseDto.java
@@ -1,0 +1,47 @@
+package com.smooth.accident_service.accident.dto;
+
+import java.time.LocalDateTime;
+import java.math.BigDecimal;
+import java.util.List;
+
+public record AccidentDetailResponseDto(
+    String accidentId,
+    UserDto user,
+    LocationDto location,
+    LocalDateTime occurredAt,
+    String severity,
+    DecelerationDto deceleration,
+    Integer severityScore,
+    EmergencyResponseDto emergencyResponse,
+    List<DrivingLogDto> drivingLogs
+) {}
+
+record UserDto(
+    String userId,
+    String userName,
+    String vehicleId
+) {}
+
+record LocationDto(
+    BigDecimal latitude,
+    BigDecimal longitude
+) {}
+
+record DecelerationDto(
+    Double peak,
+    Double avg
+) {}
+
+record EmergencyResponseDto(
+    Boolean emergencyNotified,
+    Boolean familyNotified,
+    LocalDateTime reportedTime
+) {}
+
+record DrivingLogDto(
+        Double speed,
+        Double decelerationRate,
+        Boolean brakePedal,
+        Double acceleratorPedal,
+        Integer timeOffsetSeconds
+) {}

--- a/src/main/java/com/smooth/accident_service/accident/dto/AccidentDetailResponseDto.java
+++ b/src/main/java/com/smooth/accident_service/accident/dto/AccidentDetailResponseDto.java
@@ -4,14 +4,16 @@ import java.time.LocalDateTime;
 import java.math.BigDecimal;
 import java.util.List;
 
+import com.smooth.accident_service.accident.entity.AccidentSeverityType;
+
 public record AccidentDetailResponseDto(
     String accidentId,
     UserDto user,
     LocationDto location,
-    LocalDateTime occurredAt,
-    String severity,
+    LocalDateTime accidentAt,
     DecelerationDto deceleration,
-    Integer severityScore,
+    BigDecimal impulse,
+    AccidentSeverityType severity,
     EmergencyResponseDto emergencyResponse,
     List<DrivingLogDto> drivingLogs
 ) {}
@@ -28,20 +30,21 @@ record LocationDto(
 ) {}
 
 record DecelerationDto(
-    Double peak,
-    Double avg
+    Double decel,
+    Double startSpeed,
+    Double endSpeed
 ) {}
 
 record EmergencyResponseDto(
     Boolean emergencyNotified,
     Boolean familyNotified,
-    LocalDateTime reportedTime
+    LocalDateTime reportedAt
 ) {}
 
 record DrivingLogDto(
-        Double speed,
-        Double decelerationRate,
-        Boolean brakePedal,
-        Double acceleratorPedal,
-        Integer timeOffsetSeconds
+    Double speed,
+    Double decelerationRate,
+    Boolean brakePedal,
+    Boolean acceleratorPedal,
+    Integer timeOffsetSeconds
 ) {}

--- a/src/main/java/com/smooth/accident_service/accident/dto/AccidentDetailResponseDto.java
+++ b/src/main/java/com/smooth/accident_service/accident/dto/AccidentDetailResponseDto.java
@@ -4,47 +4,14 @@ import java.time.LocalDateTime;
 import java.math.BigDecimal;
 import java.util.List;
 
-import com.smooth.accident_service.accident.entity.AccidentSeverityType;
-
 public record AccidentDetailResponseDto(
     String accidentId,
     UserDto user,
     LocationDto location,
     LocalDateTime accidentAt,
     DecelerationDto deceleration,
-    BigDecimal impulse,
-    AccidentSeverityType severity,
     EmergencyResponseDto emergencyResponse,
+    BigDecimal impulse,
+    String scale,
     List<DrivingLogDto> drivingLogs
-) {}
-
-record UserDto(
-    String userId,
-    String userName,
-    String vehicleId
-) {}
-
-record LocationDto(
-    BigDecimal latitude,
-    BigDecimal longitude
-) {}
-
-record DecelerationDto(
-    Double decel,
-    Double startSpeed,
-    Double endSpeed
-) {}
-
-record EmergencyResponseDto(
-    Boolean emergencyNotified,
-    Boolean familyNotified,
-    LocalDateTime reportedAt
-) {}
-
-record DrivingLogDto(
-    Double speed,
-    Double decelerationRate,
-    Boolean brakePedal,
-    Boolean acceleratorPedal,
-    Integer timeOffsetSeconds
 ) {}

--- a/src/main/java/com/smooth/accident_service/accident/dto/DecelerationDto.java
+++ b/src/main/java/com/smooth/accident_service/accident/dto/DecelerationDto.java
@@ -1,0 +1,7 @@
+package com.smooth.accident_service.accident.dto;
+
+public record DecelerationDto(
+    Double decel,
+    Double startSpeed,
+    Double endSpeed
+) {}

--- a/src/main/java/com/smooth/accident_service/accident/dto/DrivingLogDto.java
+++ b/src/main/java/com/smooth/accident_service/accident/dto/DrivingLogDto.java
@@ -1,0 +1,9 @@
+package com.smooth.accident_service.accident.dto;
+
+public record DrivingLogDto(
+    Double speed,
+    Double decelerationRate,
+    Boolean brakePedal,
+    Boolean acceleratorPedal,
+    Integer timeOffsetSeconds
+) {}

--- a/src/main/java/com/smooth/accident_service/accident/dto/EmergencyResponseDto.java
+++ b/src/main/java/com/smooth/accident_service/accident/dto/EmergencyResponseDto.java
@@ -1,0 +1,9 @@
+package com.smooth.accident_service.accident.dto;
+
+import java.time.LocalDateTime;
+
+public record EmergencyResponseDto(
+    Boolean emergencyNotified,
+    Boolean familyNotified,
+    LocalDateTime reportedAt
+) {}

--- a/src/main/java/com/smooth/accident_service/accident/dto/LocationDto.java
+++ b/src/main/java/com/smooth/accident_service/accident/dto/LocationDto.java
@@ -1,0 +1,8 @@
+package com.smooth.accident_service.accident.dto;
+
+import java.math.BigDecimal;
+
+public record LocationDto(
+    BigDecimal latitude,
+    BigDecimal longitude
+) {}

--- a/src/main/java/com/smooth/accident_service/accident/dto/UserDto.java
+++ b/src/main/java/com/smooth/accident_service/accident/dto/UserDto.java
@@ -1,0 +1,7 @@
+package com.smooth.accident_service.accident.dto;
+
+public record UserDto(
+    String userId,
+    String userName,
+    Long vehicleId
+) {}

--- a/src/main/java/com/smooth/accident_service/accident/entity/Accident.java
+++ b/src/main/java/com/smooth/accident_service/accident/entity/Accident.java
@@ -1,0 +1,76 @@
+package com.smooth.accident_service.accident.entity;
+
+import com.smooth.accident_service.global.config.DynamoDBConfig;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.math.BigDecimal;
+import lombok.NonNull;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@DynamoDbBean
+public class Accident {
+
+    @NonNull
+    private String accidentId;
+    private Long vehicleId;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+    @NonNull
+    private LocalDateTime accidentedAt;
+    private BigDecimal impulse;
+    @NonNull
+    private String scale;
+    private String drivingLog;
+    
+    @DynamoDbPartitionKey
+    public String getPk() {
+        return "SCALE#" + scale;
+    }
+
+    @DynamoDbSortKey
+    public String getSk() {
+        return "DATE#" + accidentedAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")) +
+                "#TIME#" + accidentedAt.format(DateTimeFormatter.ofPattern("HH:mm:ss")) +
+                "#ID#" + accidentId;
+    }
+
+    @DynamoDbConvertedBy(DynamoDBConfig.LocalDateTimeConverter.class)
+    public LocalDateTime getAccidentedAt() {
+        return accidentedAt;
+    }
+
+    @DynamoDbAttribute("timeSeriesData")
+    public String getDrivingLog() {
+        return drivingLog;
+    }
+
+    @DynamoDbSecondaryPartitionKey(indexNames = "GSI1")
+    public String getGsi1pk() {
+        return "DATE#" + accidentedAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    }
+
+    @DynamoDbSecondarySortKey(indexNames = "GSI1")
+    public String getGsi1sk() {
+        String timeStr = accidentedAt.format(DateTimeFormatter.ofPattern("HH:mm:ss"));
+        return "SCALE#" + scale + "#TIME#" + timeStr;
+    }
+
+    @DynamoDbSecondaryPartitionKey(indexNames = "GSI2")
+    public String getGsi2pk() {
+        return "MONTH#" + accidentedAt.format(DateTimeFormatter.ofPattern("yyyy-MM"));
+    }
+
+    @DynamoDbSecondarySortKey(indexNames = "GSI2")
+    public String getGsi2sk() {
+        String dateStr = accidentedAt.format(DateTimeFormatter.ofPattern("dd"));
+        String timeStr = accidentedAt.format(DateTimeFormatter.ofPattern("HH:mm:ss"));
+        return "SCALE#" + scale + "#DATE#" + dateStr + "#TIME#" + timeStr;
+    }
+}

--- a/src/main/java/com/smooth/accident_service/accident/entity/AccidentSeverityType.java
+++ b/src/main/java/com/smooth/accident_service/accident/entity/AccidentSeverityType.java
@@ -1,7 +1,0 @@
-package com.smooth.accident_service.accident.entity;
-
-public enum AccidentSeverityType {
-    LOW, 
-    MEDIUM, 
-    HIGH
-}

--- a/src/main/java/com/smooth/accident_service/accident/entity/AccidentSeverityType.java
+++ b/src/main/java/com/smooth/accident_service/accident/entity/AccidentSeverityType.java
@@ -1,0 +1,7 @@
+package com.smooth.accident_service.accident.entity;
+
+public enum AccidentSeverityType {
+    LOW, 
+    MEDIUM, 
+    HIGH
+}

--- a/src/main/java/com/smooth/accident_service/accident/entity/DrivingLog.java
+++ b/src/main/java/com/smooth/accident_service/accident/entity/DrivingLog.java
@@ -1,0 +1,43 @@
+package com.smooth.accident_service.accident.entity;
+
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+
+@Setter
+@NoArgsConstructor
+@DynamoDbBean
+public class DrivingLog {
+
+    private Double speed;
+    private Double decelerationRate;
+    private Boolean brakePedal;
+    private Boolean acceleratorPedal;
+    private Integer timeOffsetSeconds;
+
+    @DynamoDbAttribute("speed")
+    public Double getSpeed() {
+        return speed;
+    }
+
+    @DynamoDbAttribute("acceleration")
+    public Double getDecelerationRate() {
+        return decelerationRate;
+    }
+
+    @DynamoDbAttribute("brakePressure")
+    public Boolean getBrakePedal() {
+        return brakePedal;
+    }
+
+    @DynamoDbAttribute("acceleratorPressure")
+    public Boolean getAcceleratorPedal() {
+        return acceleratorPedal;
+    }
+
+    @DynamoDbAttribute("offset")
+    public Integer getTimeOffsetSeconds() {
+        return timeOffsetSeconds;
+    }
+}

--- a/src/main/java/com/smooth/accident_service/accident/repository/AccidentRepository.java
+++ b/src/main/java/com/smooth/accident_service/accident/repository/AccidentRepository.java
@@ -1,0 +1,35 @@
+package com.smooth.accident_service.accident.repository;
+
+import com.smooth.accident_service.accident.entity.Accident;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class AccidentRepository {
+
+    private final DynamoDbEnhancedClient enhancedClient;
+    
+    @Value("${dynamodb.table.name}")
+    private String tableName;
+
+    private DynamoDbTable<Accident> table;
+
+    @PostConstruct
+    void init() {
+        this.table = enhancedClient.table(tableName, TableSchema.fromBean(Accident.class));
+    }
+
+    public List<Accident> findAll() {
+        return table.scan().items().stream().collect(Collectors.toList());
+    }
+    // TODO : 쿼리 이용
+}

--- a/src/main/java/com/smooth/accident_service/accident/service/AccidentService.java
+++ b/src/main/java/com/smooth/accident_service/accident/service/AccidentService.java
@@ -1,0 +1,9 @@
+package com.smooth.accident_service.accident.service;
+
+import com.smooth.accident_service.accident.dto.AccidentDetailResponseDto;
+
+import java.util.List;
+
+public interface AccidentService {
+    List<AccidentDetailResponseDto> getAllAccidents();
+}

--- a/src/main/java/com/smooth/accident_service/accident/service/AccidentServiceImpl.java
+++ b/src/main/java/com/smooth/accident_service/accident/service/AccidentServiceImpl.java
@@ -1,0 +1,87 @@
+package com.smooth.accident_service.accident.service;
+
+import com.smooth.accident_service.accident.dto.*;
+import com.smooth.accident_service.accident.entity.Accident;
+import com.smooth.accident_service.accident.repository.AccidentRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.ArrayList;
+
+@Service
+@RequiredArgsConstructor
+public class AccidentServiceImpl implements AccidentService {
+
+    private final AccidentRepository accidentRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public List<AccidentDetailResponseDto> getAllAccidents() {
+        List<Accident> accidents = accidentRepository.findAll();
+        return accidents.stream()
+                .filter(accident -> accident != null)
+                .map(this::convertToDto)
+                .toList();
+    }
+
+    private AccidentDetailResponseDto convertToDto(Accident accident) {
+        return new AccidentDetailResponseDto(
+                accident.getAccidentId(),
+                convertToUserDto(accident),
+                convertToLocationDto(accident),
+                accident.getAccidentedAt(),
+                null,
+                null,
+                accident.getImpulse(),
+                accident.getScale(),
+                convertDrivingLogs(accident.getDrivingLog())
+        );
+    }
+
+    private List<DrivingLogDto> convertDrivingLogs(String timeSeriesDataJson) {
+        if (timeSeriesDataJson == null || timeSeriesDataJson.isEmpty()) {
+            return List.of();
+        }
+
+        try {
+            JsonNode jsonNode = objectMapper.readTree(timeSeriesDataJson);
+            JsonNode preEventArray = jsonNode.get("preEvent");
+            
+            if (preEventArray == null || !preEventArray.isArray()) {
+                return List.of();
+            }
+
+            List<DrivingLogDto> drivingLogs = new ArrayList<>();
+            for (JsonNode eventNode : preEventArray) {
+                DrivingLogDto logDto = new DrivingLogDto(
+                        eventNode.has("speed") ? eventNode.get("speed").asDouble() : null,
+                        eventNode.has("acceleration") ? eventNode.get("acceleration").asDouble() : null,
+                        eventNode.has("brakePressure") ? eventNode.get("brakePressure").asInt() > 0 : null,
+                        eventNode.has("acceleratorPressure") ? eventNode.get("acceleratorPressure").asInt() > 0 : null,
+                        eventNode.has("offset") ? eventNode.get("offset").asInt() : null
+                );
+                drivingLogs.add(logDto);
+            }
+            return drivingLogs;
+        } catch (Exception e) {
+            return List.of();
+        }
+    }
+
+    private LocationDto convertToLocationDto(Accident accident) {
+        if (accident.getLatitude() == null || accident.getLongitude() == null) {
+            return null;
+        }
+        return new LocationDto(accident.getLatitude(), accident.getLongitude());
+    }
+
+    private UserDto convertToUserDto(Accident accident) {
+        if (accident.getVehicleId() == null) {
+            return null;
+        }
+        return new UserDto(null, null, accident.getVehicleId());
+    }
+}

--- a/src/main/java/com/smooth/accident_service/global/config/DynamoDBConfig.java
+++ b/src/main/java/com/smooth/accident_service/global/config/DynamoDBConfig.java
@@ -14,20 +14,18 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 
 @Configuration
 public class DynamoDBConfig {
 
-    @Value("${cloud.aws.region.static}")
+    @Value("${region:}")
     private String region;
 
-    @Value("${cloud.aws.credentials.access-key}")
+    @Value("${access-key}")
     private String accessKey;
 
-    @Value("${cloud.aws.credentials.secret-key}")
+    @Value("${secret-key}")
     private String secretKey;
 
     @Bean
@@ -50,12 +48,12 @@ public class DynamoDBConfig {
     public static class LocalDateTimeConverter implements AttributeConverter<LocalDateTime> {
         @Override
         public AttributeValue transformFrom(LocalDateTime input) {
-            return AttributeValue.builder().s(input.toInstant(ZoneOffset.UTC).toString()).build();
+            return AttributeValue.builder().s(input.toString()).build();
         }
 
         @Override
         public LocalDateTime transformTo(AttributeValue input) {
-            return LocalDateTime.ofInstant(Instant.parse(input.s()), ZoneOffset.UTC);
+            return LocalDateTime.parse(input.s());
         }
 
         @Override

--- a/src/main/java/com/smooth/accident_service/global/config/DynamoDBConfig.java
+++ b/src/main/java/com/smooth/accident_service/global/config/DynamoDBConfig.java
@@ -1,0 +1,71 @@
+package com.smooth.accident_service.global.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+@Configuration
+public class DynamoDBConfig {
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public DynamoDbClient dynamoDbClient() {
+        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return DynamoDbClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .build();
+    }
+
+    @Bean
+    public DynamoDbEnhancedClient dynamoDbEnhancedClient(@Qualifier("dynamoDbClient") DynamoDbClient dynamoDbClient) {
+        return DynamoDbEnhancedClient.builder()
+                .dynamoDbClient(dynamoDbClient)
+                .build();
+    }
+
+    public static class LocalDateTimeConverter implements AttributeConverter<LocalDateTime> {
+        @Override
+        public AttributeValue transformFrom(LocalDateTime input) {
+            return AttributeValue.builder().s(input.toInstant(ZoneOffset.UTC).toString()).build();
+        }
+
+        @Override
+        public LocalDateTime transformTo(AttributeValue input) {
+            return LocalDateTime.ofInstant(Instant.parse(input.s()), ZoneOffset.UTC);
+        }
+
+        @Override
+        public EnhancedType<LocalDateTime> type() {
+            return EnhancedType.of(LocalDateTime.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+}


### PR DESCRIPTION
#  PR: T11.3.1 - 사고 조회 기본 구조 및 DTO 설계 → US11.3 머지

## 목적
- 관리자 대시보드용 사고 조회 기본 구조 및 DTO 설계

---

## 구현/변경 사항
- `entity, repository, service, service impl, dto, config` 등 기본 구조를 구현했습니다.
- 현재 다이나모 디비에서 전체 사고 조회용 서비스, 레파지토리 코드를 구현했습니다. (쿼리 아님) 
- 프론트에서 보내야 하는 통합 `DTO` 안에 유저 정보, 응급 정보 등 섹션 별로 나뉘어져 있습니다.
- 1초부터 10초까지의 `time data`는 `Driving log` 이름으로 매핑하도록 하였고 별도 `entity`로 구현했습니다.

---

## 참고
- gsi 구현 필요합니다.