### PR TITLE
PR: T11.3.3 - 사고 조회 페이지네이션 구현 → US11.3 머지

### DIFF
--- a/src/main/java/com/smooth/accident_service/AccidentServiceApplication.java
+++ b/src/main/java/com/smooth/accident_service/AccidentServiceApplication.java
@@ -4,11 +4,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
+import java.util.TimeZone;
+
 @EnableFeignClients
 @SpringBootApplication
 public class AccidentServiceApplication {
 
     public static void main(String[] args) {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
         SpringApplication.run(AccidentServiceApplication.class, args);
     }
 

--- a/src/main/java/com/smooth/accident_service/accident/dto/AccidentPageResponseDto.java
+++ b/src/main/java/com/smooth/accident_service/accident/dto/AccidentPageResponseDto.java
@@ -1,0 +1,14 @@
+package com.smooth.accident_service.accident.dto;
+
+import java.util.List;
+
+public record AccidentPageResponseDto(
+    List<AccidentDetailResponseDto> content,
+    int page,
+    int totalPages
+) {
+    public static AccidentPageResponseDto of(List<AccidentDetailResponseDto> content, int page, int totalElements) {
+        int totalPages = (int) Math.ceil((double) totalElements / 10);
+        return new AccidentPageResponseDto(content, page, totalPages);
+    }
+}

--- a/src/main/java/com/smooth/accident_service/accident/entity/Accident.java
+++ b/src/main/java/com/smooth/accident_service/accident/entity/Accident.java
@@ -3,13 +3,13 @@ package com.smooth.accident_service.accident.entity;
 import com.smooth.accident_service.global.dynamoDb.LocalDateTimeConverter;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import lombok.Setter;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.*;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.math.BigDecimal;
-import lombok.NonNull;
 
 @Setter
 @Getter
@@ -33,19 +33,29 @@ public class Accident {
 
     @NonNull
     private String scale;
-    
+
     private String drivingLog;
-    
+
     @DynamoDbPartitionKey
+    @DynamoDbAttribute("PK")
     public String getPk() {
         return "SCALE#" + scale;
     }
 
+    public void setPk(String pk) {
+
+    }
+
     @DynamoDbSortKey
+    @DynamoDbAttribute("SK")
     public String getSk() {
         return "DATE#" + accidentedAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")) +
                 "#TIME#" + accidentedAt.format(DateTimeFormatter.ofPattern("HH:mm:ss")) +
                 "#ID#" + accidentId;
+    }
+
+    public void setSk(String sk) {
+
     }
 
     @DynamoDbConvertedBy(LocalDateTimeConverter.class)
@@ -59,25 +69,45 @@ public class Accident {
     }
 
     @DynamoDbSecondaryPartitionKey(indexNames = "GSI1")
+    @DynamoDbAttribute("GSI1PK")
     public String getGsi1pk() {
         return "DATE#" + accidentedAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
     }
 
+    public void setGsi1pk(String gsi1pk) {
+
+    }
+
     @DynamoDbSecondarySortKey(indexNames = "GSI1")
+    @DynamoDbAttribute("GSI1SK")
     public String getGsi1sk() {
         String timeStr = accidentedAt.format(DateTimeFormatter.ofPattern("HH:mm:ss"));
         return "SCALE#" + scale + "#TIME#" + timeStr;
     }
 
+    public void setGsi1sk(String gsi1sk) {
+        // Do nothing.
+    }
+
     @DynamoDbSecondaryPartitionKey(indexNames = "GSI2")
+    @DynamoDbAttribute("GSI2PK")
     public String getGsi2pk() {
         return "MONTH#" + accidentedAt.format(DateTimeFormatter.ofPattern("yyyy-MM"));
     }
+    // 👇 수정된 부분: 스캐너 인식을 위한 더미 setter 추가
+    public void setGsi2pk(String gsi2pk) {
+
+    }
 
     @DynamoDbSecondarySortKey(indexNames = "GSI2")
+    @DynamoDbAttribute("GSI2SK")
     public String getGsi2sk() {
         String dateStr = accidentedAt.format(DateTimeFormatter.ofPattern("dd"));
         String timeStr = accidentedAt.format(DateTimeFormatter.ofPattern("HH:mm:ss"));
         return "SCALE#" + scale + "#DATE#" + dateStr + "#TIME#" + timeStr;
+    }
+
+    public void setGsi2sk(String gsi2sk) {
+
     }
 }

--- a/src/main/java/com/smooth/accident_service/accident/repository/AccidentRepository.java
+++ b/src/main/java/com/smooth/accident_service/accident/repository/AccidentRepository.java
@@ -1,14 +1,18 @@
 package com.smooth.accident_service.accident.repository;
 
 import com.smooth.accident_service.accident.entity.Accident;
+import com.smooth.accident_service.accident.exception.AccidentErrorCode;
+import com.smooth.accident_service.global.exception.BusinessException;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
-import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
-import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.*;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -17,19 +21,103 @@ import java.util.stream.Collectors;
 public class AccidentRepository {
 
     private final DynamoDbEnhancedClient enhancedClient;
-    
+
     @Value("${dynamodb.table.name}")
     private String tableName;
 
     private DynamoDbTable<Accident> table;
+    private DynamoDbIndex<Accident> gsi1Index;
 
     @PostConstruct
     void init() {
         this.table = enhancedClient.table(tableName, TableSchema.fromBean(Accident.class));
+        this.gsi1Index = table.index("GSI1");
     }
 
     public List<Accident> findAll() {
-        return table.scan().items().stream().collect(Collectors.toList());
+        List<Accident> accidents = table.scan().items().stream().collect(Collectors.toList());
+        System.out.println("조회된 사고 데이터 개수: " + accidents.size());
+        accidents.forEach(accident -> {
+            System.out.println("사고 데이터: " + accident);
+            System.out.println("accidentedAt: " + (accident != null ? accident.getAccidentedAt() : "null"));
+        });
+        return accidents;
     }
-    // TODO : 쿼리 이용
+
+    public List<Accident> findAllDesc() {
+        return table.scan().items().stream()
+                .filter(accident -> accident != null && accident.getAccidentedAt() != null)
+                .sorted((a1, a2) -> a2.getAccidentedAt().compareTo(a1.getAccidentedAt()))
+                .collect(Collectors.toList());
+    }
+
+    public List<Accident> findByDateRange(LocalDate startDate, LocalDate endDate) {
+        return startDate.datesUntil(endDate.plusDays(1))
+                .parallel()
+                .flatMap(date -> {
+                    String dateKey = "DATE#" + date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+                    QueryConditional queryConditional = QueryConditional
+                            .keyEqualTo(Key.builder()
+                                    .partitionValue(dateKey)
+                                    .build());
+
+                    QueryEnhancedRequest queryRequest = QueryEnhancedRequest.builder()
+                            .queryConditional(queryConditional)
+                            .scanIndexForward(false)
+                            .build();
+
+                    return gsi1Index.query(queryRequest)
+                            .stream()
+                            .flatMap(page -> page.items().stream());
+                })
+                .collect(Collectors.toList());
+    }
+
+    public List<Accident> findByScale(String scale) {
+        String scaleKey = "SCALE#" + scale;
+
+        QueryConditional queryConditional = QueryConditional
+                .keyEqualTo(Key.builder()
+                        .partitionValue(scaleKey)
+                        .build());
+
+        QueryEnhancedRequest queryRequest = QueryEnhancedRequest.builder()
+                .queryConditional(queryConditional)
+                .scanIndexForward(false)
+                .build();
+
+        return table.query(queryRequest)
+                .items()
+                .stream()
+                .collect(Collectors.toList());
+    }
+
+    public List<Accident> findByDateRangeAndScale(LocalDate startDate, LocalDate endDate, String scale) {
+
+        return startDate.datesUntil(endDate.plusDays(1))
+                .parallel()
+                .flatMap(date -> {
+                    String dateKey = "DATE#" + date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                    String scalePrefix = "SCALE#" + scale;
+
+                    QueryConditional queryConditional = QueryConditional
+                            .sortBeginsWith(
+                                    Key.builder()
+                                            .partitionValue(dateKey)
+                                            .sortValue(scalePrefix)
+                                            .build()
+                            );
+
+                    QueryEnhancedRequest queryRequest = QueryEnhancedRequest.builder()
+                            .queryConditional(queryConditional)
+                            .scanIndexForward(false)
+                            .build();
+
+                    return gsi1Index.query(queryRequest)
+                            .stream()
+                            .flatMap(page -> page.items().stream());
+                })
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/smooth/accident_service/accident/service/AccidentService.java
+++ b/src/main/java/com/smooth/accident_service/accident/service/AccidentService.java
@@ -1,9 +1,14 @@
 package com.smooth.accident_service.accident.service;
 
 import com.smooth.accident_service.accident.dto.AccidentDetailResponseDto;
+import com.smooth.accident_service.accident.dto.AccidentPageResponseDto;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface AccidentService {
+
     List<AccidentDetailResponseDto> getAllAccidents();
+
+    AccidentPageResponseDto getAccidents(int page, LocalDate start, LocalDate end, String scale);
 }


### PR DESCRIPTION
# PR: T11.3.3 - 사고 조회 페이지네이션 구현 → US11.3 머지

## 목적
- 관리자 대시보드용 사고 조회 open feign 구현

---

## 구현/변경 사항
- 유저서비스, 드라이브캐스트에서 필요한 정보를 위한 open feign을 구현했습니다.
- dto 유저 타입을 string -> long으로 통일했습니다.

---

## 테스트
- 다이나모디비, feign 로컬 테스트 완료

## 참고
- 유저서비스 open feign client에서 현 유저 서비스에 구현되어있는 api와 형태를 맞추었기 때문에 공통 응답이 빠져있습니다. 추후 리팩토링 예정입니다.
- 차량 아이디가 유저 아이디와 같기 때문에 유저서비스에서 유저 아이디로 조회하는 open feign용 api를 이용했습니다.
- Closes #4 