### PR TITLE
PR: T11.3.4 - 관리자 대시보드 사고 조회용 API 구현→ US11.3 머지

### DIFF
--- a/src/main/java/com/smooth/accident_service/accident/controller/AccidentController.java
+++ b/src/main/java/com/smooth/accident_service/accident/controller/AccidentController.java
@@ -1,23 +1,59 @@
 package com.smooth.accident_service.accident.controller;
 
 import com.smooth.accident_service.accident.dto.AccidentDetailResponseDto;
+import com.smooth.accident_service.accident.dto.AccidentPageResponseDto;
+import com.smooth.accident_service.accident.exception.AccidentErrorCode;
 import com.smooth.accident_service.accident.service.AccidentService;
+import com.smooth.accident_service.global.auth.AuthenticationUtils;
+import com.smooth.accident_service.global.common.ApiResponse;
+import com.smooth.accident_service.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
 import java.util.List;
 
-@RestController
-@RequestMapping("/api/accidents")
 @RequiredArgsConstructor
+@RequestMapping("/api/accidents")
+@RestController
 public class AccidentController {
 
     private final AccidentService accidentService;
 
     @GetMapping
+    public ResponseEntity<ApiResponse<AccidentPageResponseDto>> getAccidents(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end,
+            @RequestParam(required = false) String scale) {
+
+        if (!AuthenticationUtils.isAdmin()) {
+            throw new BusinessException(AccidentErrorCode.ADMIN_ONLY_ACCESS);
+        }
+
+        if (scale != null && !scale.equals("medium") && !scale.equals("high")) {
+            throw new BusinessException(AccidentErrorCode.INVALID_SCALE_VALUE);
+        }
+
+        AccidentPageResponseDto responseDto = accidentService.getAccidents(page, start, end, scale);
+        return ResponseEntity.ok(ApiResponse.success("사고 조회가 완료되었습니다.", responseDto));
+
+    }
+
+
+    @GetMapping("/all")
     public List<AccidentDetailResponseDto> getAllAccidents() {
+
+        if (!AuthenticationUtils.isAdmin()) {
+            throw new BusinessException(AccidentErrorCode.ADMIN_ONLY_ACCESS);
+        }
+
         return accidentService.getAllAccidents();
     }
 }

--- a/src/main/java/com/smooth/accident_service/accident/exception/AccidentErrorCode.java
+++ b/src/main/java/com/smooth/accident_service/accident/exception/AccidentErrorCode.java
@@ -1,0 +1,19 @@
+package com.smooth.accident_service.accident.exception;
+
+import com.smooth.accident_service.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AccidentErrorCode implements ErrorCode {
+
+    INVALID_PAGE_NUMBER(HttpStatus.BAD_REQUEST, 6400, "유효하지 않은 페이지 번호입니다."),
+    INVALID_SCALE_VALUE(HttpStatus.BAD_REQUEST, 6401, "유효하지 않은 사고 등급입니다. (medium, high만 허용)"),
+    ADMIN_ONLY_ACCESS(HttpStatus.FORBIDDEN, 6403, "관리자만 접근 가능합니다.");
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+    private final String message;
+}

--- a/src/main/java/com/smooth/accident_service/global/auth/AuthenticationUtils.java
+++ b/src/main/java/com/smooth/accident_service/global/auth/AuthenticationUtils.java
@@ -1,0 +1,105 @@
+package com.smooth.accident_service.global.auth;
+
+import com.smooth.accident_service.global.exception.BusinessException;
+import com.smooth.accident_service.global.exception.CommonErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+
+@Slf4j
+public class AuthenticationUtils {
+
+    private static final String USER_ID_HEADER = "X-User-Id";
+    private static final String USER_EMAIL_HEADER = "X-User-Email";
+    private static final String USER_ROLE_HEADER = "X-User-Role";
+    private static final String AUTHENTICATED_HEADER = "X-Authenticated";
+
+
+    public static Long getCurrentUserId() {
+        return getUserIdFromHeader();
+    }
+
+    public static Long getCurrentUserIdOrThrow() {
+        Long userId = getCurrentUserId();
+        if (userId == null) {
+            throw new BusinessException(CommonErrorCode.UNAUTHORIZED, "인증되지 않은 사용자입니다.");
+        }
+        return userId;
+    }
+
+    public static String getCurrentUserEmail() {
+        return getUserEmailFromHeader();
+    }
+
+    public static String getCurrentUserRole() {
+        return getUserRoleFromHeader();
+    }
+
+    public static boolean isAdmin() {
+        String role = getCurrentUserRole();
+        boolean isAdminResult = "ADMIN".equals(role);
+        log.info("isAdmin() 체크 - role: {}, isAdmin: {}", role, isAdminResult);
+        return isAdminResult;
+    }
+
+    public static boolean isAuthenticated() {
+        return getCurrentUserId() != null;
+    }
+
+    private static Long getUserIdFromHeader() {
+        try {
+            ServletRequestAttributes attr = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+            HttpServletRequest request = attr.getRequest();
+            String userIdHeader = request.getHeader(USER_ID_HEADER);
+            String authenticatedHeader = request.getHeader(AUTHENTICATED_HEADER);
+
+            log.info("헤더 확인 - X-User-Id: {}, X-Authenticated: {}", userIdHeader, authenticatedHeader);
+
+            if (StringUtils.hasText(userIdHeader) && "true".equals(authenticatedHeader)) {
+                return Long.valueOf(userIdHeader);
+            }
+        } catch (Exception e) {
+            log.debug("HTTP 헤더에서 사용자 ID 추출 실패: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    private static String getUserEmailFromHeader() {
+        try {
+            ServletRequestAttributes attr = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+            HttpServletRequest request = attr.getRequest();
+            String emailHeader = request.getHeader(USER_EMAIL_HEADER);
+            String authenticatedHeader = request.getHeader(AUTHENTICATED_HEADER);
+
+            if (StringUtils.hasText(emailHeader) && "true".equals(authenticatedHeader)) {
+                return emailHeader;
+            }
+        } catch (Exception e) {
+            log.debug("HTTP 헤더에서 사용자 이메일 추출 실패: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    private static String getUserRoleFromHeader() {
+        try {
+            ServletRequestAttributes attr = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+            HttpServletRequest request = attr.getRequest();
+            String roleHeader = request.getHeader(USER_ROLE_HEADER);
+            String authenticatedHeader = request.getHeader(AUTHENTICATED_HEADER);
+
+            log.info("헤더 확인 - X-User-Role: {}, X-Authenticated: {}", roleHeader, authenticatedHeader);
+
+            if (StringUtils.hasText(roleHeader) && "true".equals(authenticatedHeader)) {
+                log.info("관리자 권한 확인됨: {}", roleHeader);
+                return roleHeader;
+            }
+        } catch (Exception e) {
+            log.debug("HTTP 헤더에서 사용자 역할 추출 실패: {}", e.getMessage());
+        }
+        log.info("기본 사용자 권한으로 설정됨");
+        return "USER";
+    }
+}


### PR DESCRIPTION
# PR: T11.3.4 - 관리자 대시보드 사고 조회용 API 구현 → US11.3 머지

## 목적
- 관리자 대시보드용 사고 조회 open feign 구현

---

## 구현/변경 사항
- 유저서비스, 드라이브캐스트에서 필요한 정보를 위한 open feign을 구현했습니다.
- dto 유저 타입을 string -> long으로 통일했습니다.

---

## 테스트
- 다이나모디비, feign 로컬 테스트 완료

## 참고
- 유저서비스 open feign client에서 현 유저 서비스에 구현되어있는 api와 형태를 맞추었기 때문에 공통 응답이 빠져있습니다. 추후 리팩토링 예정입니다.
- 차량 아이디가 유저 아이디와 같기 때문에 유저서비스에서 유저 아이디로 조회하는 open feign용 api를 이용했습니다.
- Closes #4 