### PR TITLE
PR: fix-US11.3 - 사고 Id 혹은 차량 Id가 없을 경우 오류 방지→ dev 머지

### DIFF
--- a/src/main/java/com/smooth/accident_service/accident/entity/Accident.java
+++ b/src/main/java/com/smooth/accident_service/accident/entity/Accident.java
@@ -86,7 +86,7 @@ public class Accident {
     }
 
     public void setGsi1sk(String gsi1sk) {
-        // Do nothing.
+
     }
 
     @DynamoDbSecondaryPartitionKey(indexNames = "GSI2")
@@ -94,7 +94,7 @@ public class Accident {
     public String getGsi2pk() {
         return "MONTH#" + accidentedAt.format(DateTimeFormatter.ofPattern("yyyy-MM"));
     }
-    // 👇 수정된 부분: 스캐너 인식을 위한 더미 setter 추가
+
     public void setGsi2pk(String gsi2pk) {
 
     }

--- a/src/main/java/com/smooth/accident_service/accident/service/AccidentServiceImpl.java
+++ b/src/main/java/com/smooth/accident_service/accident/service/AccidentServiceImpl.java
@@ -130,6 +130,9 @@ public class AccidentServiceImpl implements AccidentService {
     }
     
     private EmergencyResponseDto convertToEmergencyResponse(Accident accident) {
+        if (accident.getVehicleId() == null || accident.getAccidentId().trim().isEmpty()) {
+            return null;
+        }
         return clientAdapter.getEmergencyResponse(accident.getAccidentId());
     }
 }


### PR DESCRIPTION
# PR: fix-US11.3 - 사고 Id 혹은 차량 Id가 없을 경우 오류 방지→ dev 머지

## 목적
- 관리자 대시보드용 사고 조회 open feign 구현

---

## 구현/변경 사항
- 유저서비스, 드라이브캐스트에서 필요한 정보를 위한 open feign을 구현했습니다.
- dto 유저 타입을 string -> long으로 통일했습니다.

---

## 테스트
- 다이나모디비, feign 로컬 테스트 완료

## 참고
- 유저서비스 open feign client에서 현 유저 서비스에 구현되어있는 api와 형태를 맞추었기 때문에 공통 응답이 빠져있습니다. 추후 리팩토링 예정입니다.
- 차량 아이디가 유저 아이디와 같기 때문에 유저서비스에서 유저 아이디로 조회하는 open feign용 api를 이용했습니다.